### PR TITLE
Add definition for TaskQueue realtime statistics

### DIFF
--- a/api-descriptors/taskrouter/v1/task_queue_cumulative_statistics.json
+++ b/api-descriptors/taskrouter/v1/task_queue_cumulative_statistics.json
@@ -1,0 +1,139 @@
+{
+    "fetch": [
+        {
+            "name": "fetch",
+            "request": {
+                "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "method": "GET",
+                "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "StartDate": "2015-07-30T20:00:00Z",
+                    "EndDate": "2015-07-30T20:00:00Z"
+                }
+            },
+            "downstream_request": {
+                "form_params": {},
+                "method": "GET",
+                "query_params": {
+                    "EndDate": "2015-07-30T20:00:00Z",
+                    "StartDate": "2015-07-30T20:00:00Z"
+                },
+                "url": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics"
+            },
+            "downstream_response": {
+                "status_code": 200,
+                "content": {
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_created": 100,
+                    "reservations_accepted": 100,
+                    "reservations_rejected": 100,
+                    "reservations_timed_out": 100,
+                    "reservations_canceled": 100,
+                    "reservations_rescinded": 100,
+                    "tasks_canceled": 100,
+                    "tasks_deleted": 100,
+                    "tasks_completed": 100,
+                    "avg_task_acceptance_time": 100,
+                    "wait_duration_until_canceled": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "wait_duration_until_accepted": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "split_by_wait_time": {
+                        "5": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        },
+                        "10": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        }
+                    },
+                    "tasks_entered": 100,
+                    "tasks_moved": 100,
+                    "task_queue_sid": "WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "start_time": 1438286400,
+                    "end_time": 1438286400,
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            },
+            "response": {
+                "status_code": 200,
+                "content": {
+                    "reservations_created": 100,
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_rejected": 100,
+                    "tasks_completed": 100,
+                    "end_time": "2015-07-30T20:00:00Z",
+                    "tasks_entered": 100,
+                    "tasks_canceled": 100,
+                    "reservations_accepted": 100,
+                    "task_queue_sid": "WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_timed_out": 100,
+                    "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                    "wait_duration_until_canceled": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "wait_duration_until_accepted": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "split_by_wait_time": {
+                        "5": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        },
+                        "10": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        }
+                    },
+                    "start_time": "2015-07-30T20:00:00Z",
+                    "tasks_moved": 100,
+                    "reservations_canceled": 100,
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "tasks_deleted": 100,
+                    "reservations_rescinded": 100,
+                    "avg_task_acceptance_time": 100
+                }
+            }
+        }
+    ]
+}

--- a/api-descriptors/taskrouter/v1/task_queue_real_time_statistics.json
+++ b/api-descriptors/taskrouter/v1/task_queue_real_time_statistics.json
@@ -1,0 +1,107 @@
+{
+    "fetch": [
+        {
+            "name": "fetch",
+            "request": {
+                "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "method": "GET",
+                "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "TaskChannel": "voice"
+                }
+            },
+            "downstream_request": {
+                "form_params": {},
+                "method": "GET",
+                "query_params": {
+                    "TaskChannelUniqueName": "voice"
+                },
+                "url": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics"
+            },
+            "downstream_response": {
+                "status_code": 200,
+                "content": {
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "longest_task_waiting_age": 100,
+                    "total_tasks": 100,
+                    "total_eligible_workers": 100,
+                    "total_available_workers": 100,
+                    "tasks_by_status": {
+                        "reserved": 0,
+                        "pending": 0,
+                        "assigned": 0,
+                        "wrapping": 0
+                    },
+                    "tasks_by_priority": {},
+                    "activity_statistics": [
+                        {
+                            "friendly_name": "Idle",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Busy",
+                            "workers": 9,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Offline",
+                            "workers": 6,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Reserved",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ],
+                    "task_queue_sid": "WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            },
+            "response": {
+                "status_code": 200,
+                "content": {
+                    "longest_task_waiting_age": 100,
+                    "task_queue_sid": "WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "tasks_by_status": {
+                        "reserved": 0,
+                        "pending": 0,
+                        "assigned": 0,
+                        "wrapping": 0
+                    },
+                    "total_eligible_workers": 100,
+                    "activity_statistics": [
+                        {
+                            "friendly_name": "Idle",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Busy",
+                            "workers": 9,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Offline",
+                            "workers": 6,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Reserved",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ],
+                    "tasks_by_priority": {},
+                    "total_tasks": 100,
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "total_available_workers": 100,
+                    "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/TaskQueues/WQaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics"
+                }
+            }
+        }
+    ]
+}

--- a/api-descriptors/taskrouter/v1/workflow_cumulative_statistics.json
+++ b/api-descriptors/taskrouter/v1/workflow_cumulative_statistics.json
@@ -1,0 +1,141 @@
+{
+    "fetch": [
+        {
+            "name": "fetch",
+            "request": {
+                "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "method": "GET",
+                "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "EndDate": "2015-07-30T20:00:00Z",
+                    "StartDate": "2015-07-30T20:00:00Z"
+                }
+            },
+            "downstream_request": {
+                "method": "GET",
+                "url": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "EndDate": "2015-07-30T20:00:00Z",
+                    "StartDate": "2015-07-30T20:00:00Z"
+                }
+            },
+            "downstream_response": {
+                "status_code": 200,
+                "content": {
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_created": 100,
+                    "reservations_accepted": 100,
+                    "reservations_rejected": 100,
+                    "reservations_timed_out": 100,
+                    "reservations_canceled": 100,
+                    "reservations_rescinded": 100,
+                    "tasks_canceled": 100,
+                    "tasks_deleted": 100,
+                    "tasks_completed": 100,
+                    "avg_task_acceptance_time": 100,
+                    "wait_duration_until_canceled": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "wait_duration_until_accepted": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "split_by_wait_time": {
+                        "5": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        },
+                        "10": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        }
+                    },
+                    "tasks_entered": 100,
+                    "tasks_moved": 100,
+                    "tasks_timed_out_in_workflow": 100,
+                    "workflow_sid": "WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "start_time": 1438286400,
+                    "end_time": 1438286400,
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            },
+            "response": {
+                "content": {
+                    "avg_task_acceptance_time": 100,
+                    "tasks_canceled": 100,
+                    "start_time": "2015-07-30T20:00:00Z",
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "tasks_moved": 100,
+                    "tasks_entered": 100,
+                    "wait_duration_until_canceled": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "wait_duration_until_accepted": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "split_by_wait_time": {
+                        "5": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        },
+                        "10": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        }
+                    },
+                    "reservations_canceled": 100,
+                    "end_time": "2015-07-30T20:00:00Z",
+                    "workflow_sid": "WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_created": 100,
+                    "reservations_accepted": 100,
+                    "reservations_rescinded": 100,
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_rejected": 100,
+                    "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                    "tasks_deleted": 100,
+                    "tasks_timed_out_in_workflow": 100,
+                    "tasks_completed": 100,
+                    "reservations_timed_out": 100
+                },
+                "status_code": 200
+            }
+        }
+    ]
+}

--- a/api-descriptors/taskrouter/v1/workflow_real_time_statistics.json
+++ b/api-descriptors/taskrouter/v1/workflow_real_time_statistics.json
@@ -1,0 +1,59 @@
+{
+    "fetch": [
+        {
+            "name": "fetch",
+            "request": {
+                "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "method": "GET",
+                "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "TaskChannel": "voice"
+                }
+            },
+            "downstream_request": {
+                "method": "GET",
+                "url": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "TaskChannelUniqueName": "voice"
+                }
+            },
+            "downstream_response": {
+                "status_code": 200,
+                "content": {
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "longest_task_waiting_age": 100,
+                    "total_tasks": 100,
+                    "tasks_by_status": {
+                        "reserved": 0,
+                        "pending": 0,
+                        "assigned": 0,
+                        "wrapping": 0
+                    },
+                    "tasks_by_priority": {},
+                    "workflow_sid": "WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            },
+            "response": {
+                "content": {
+                    "longest_task_waiting_age": 100,
+                    "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workflows/WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                    "tasks_by_priority": {},
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "tasks_by_status": {
+                        "reserved": 0,
+                        "pending": 0,
+                        "assigned": 0,
+                        "wrapping": 0
+                    },
+                    "workflow_sid": "WWaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "total_tasks": 100,
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                "status_code": 200
+            }
+        }
+    ]
+}

--- a/api-descriptors/taskrouter/v1/workspace_cumulative_statistics.json
+++ b/api-descriptors/taskrouter/v1/workspace_cumulative_statistics.json
@@ -1,0 +1,139 @@
+{
+    "fetch": [
+        {
+            "name": "fetch",
+            "request": {
+                "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "method": "GET",
+                "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "EndDate": "2015-07-30T20:00:00Z",
+                    "StartDate": "2015-07-30T20:00:00Z"
+                }
+            },
+            "downstream_request": {
+                "method": "GET",
+                "url": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "EndDate": "2015-07-30T20:00:00Z",
+                    "StartDate": "2015-07-30T20:00:00Z"
+                }
+            },
+            "downstream_response": {
+                "status_code": 200,
+                "content": {
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "reservations_created": 100,
+                    "reservations_accepted": 100,
+                    "reservations_rejected": 100,
+                    "reservations_timed_out": 100,
+                    "reservations_canceled": 100,
+                    "reservations_rescinded": 100,
+                    "tasks_canceled": 100,
+                    "tasks_deleted": 100,
+                    "tasks_completed": 100,
+                    "avg_task_acceptance_time": 100,
+                    "wait_duration_until_canceled": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "wait_duration_until_accepted": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "split_by_wait_time": {
+                        "5": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        },
+                        "10": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        }
+                    },
+                    "tasks_created": 100,
+                    "tasks_moved": 100,
+                    "tasks_timed_out_in_workflow": 100,
+                    "start_time": 1438286400,
+                    "end_time": 1438286400,
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            },
+            "response": {
+                "content": {
+                    "reservations_accepted": 100,
+                    "tasks_completed": 100,
+                    "start_time": "2015-07-30T20:00:00Z",
+                    "reservations_rescinded": 100,
+                    "tasks_timed_out_in_workflow": 100,
+                    "end_time": "2015-07-30T20:00:00Z",
+                    "avg_task_acceptance_time": 100,
+                    "tasks_canceled": 100,
+                    "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/CumulativeStatistics",
+                    "tasks_moved": 100,
+                    "tasks_deleted": 100,
+                    "tasks_created": 100,
+                    "reservations_canceled": 100,
+                    "reservations_timed_out": 100,
+                    "wait_duration_until_canceled": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "wait_duration_until_accepted": {
+                        "avg": 0,
+                        "min": 0,
+                        "max": 0,
+                        "total": 0
+                    },
+                    "split_by_wait_time": {
+                        "5": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        },
+                        "10": {
+                            "above": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            },
+                            "below": {
+                                "tasks_canceled": 0,
+                                "reservations_accepted": 0
+                            }
+                        }
+                    },
+                    "reservations_created": 100,
+                    "reservations_rejected": 100,
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                },
+                "status_code": 200
+            }
+        }
+    ]
+}

--- a/api-descriptors/taskrouter/v1/workspace_real_time_statistics.json
+++ b/api-descriptors/taskrouter/v1/workspace_real_time_statistics.json
@@ -1,0 +1,93 @@
+{
+    "fetch": [
+        {
+            "name": "fetch",
+            "request": {
+                "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "method": "GET",
+                "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "TaskChannel": "voice"
+                }
+            },
+            "downstream_request": {
+                "method": "GET",
+                "url": "/2010-04-01/Accounts/ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                "form_params": {},
+                "query_params": {
+                    "TaskChannelUniqueName": "voice"
+                }
+            },
+            "downstream_response": {
+                "status_code": 200,
+                "content": {
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "longest_task_waiting_age": 100,
+                    "total_tasks": 100,
+                    "total_workers": 100,
+                    "tasks_by_status": {},
+                    "tasks_by_priority": {},
+                    "activity_statistics": [
+                        {
+                            "friendly_name": "Idle",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Busy",
+                            "workers": 9,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Offline",
+                            "workers": 6,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Reserved",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ],
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                }
+            },
+            "response": {
+                "content": {
+                    "url": "https://taskrouter.twilio.com/v1/Workspaces/WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa/RealTimeStatistics",
+                    "tasks_by_priority": {},
+                    "activity_statistics": [
+                        {
+                            "friendly_name": "Idle",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Busy",
+                            "workers": 9,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Offline",
+                            "workers": 6,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        },
+                        {
+                            "friendly_name": "Reserved",
+                            "workers": 0,
+                            "sid": "WAaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+                        }
+                    ],
+                    "workspace_sid": "WSaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "longest_task_waiting_age": 100,
+                    "total_workers": 100,
+                    "total_tasks": 100,
+                    "account_sid": "ACaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                    "tasks_by_status": {}
+                },
+                "status_code": 200
+            }
+        }
+    ]
+}


### PR DESCRIPTION
Add missing definitions to fix the issues shown for making the pull request TwilioDevEd/api-snippets#519 to pass.

New definitions:
- Task Queue
  - Real-time statistics
  - Cumulative
- Workflow
  - Real-time statistics
  - Cumulative
- Workspace
  - Real-time statistics
  - Cumulative

TODO

- [x] Test the referenced pull request locally 